### PR TITLE
[del-5544]: add delegate name as prefix of delegate-service name

### DIFF
--- a/delegate-template.yaml
+++ b/delegate-template.yaml
@@ -126,7 +126,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: delegate-service
+  name: PUT_YOUR_DELEGATE_NAME-delegate-service
   namespace: harness-delegate-ng
 spec:
   type: ClusterIP


### PR DESCRIPTION
Remove delegate-service.
This kubernetes resources is not name prefixed with delegate name, thus it blocks customers from creating multiple delegate releases in the same namespace (using helm).
<img width="1152" alt="Screen Shot 2022-12-09 at 12 21 11 PM" src="https://user-images.githubusercontent.com/109999795/206789741-1aa034ef-53b8-42da-bcc3-ae275b04b331.png">
<img width="1341" alt="Screen Shot 2022-12-09 at 12 22 23 PM" src="https://user-images.githubusercontent.com/109999795/206789796-a7951534-9b51-423c-ae74-56c78b7a4550.png">

