### PR TITLE
fix: [DEL-5592]: delegate deployment name needs to be 'delegate'

### DIFF
--- a/delegate-template.yaml
+++ b/delegate-template.yaml
@@ -39,7 +39,7 @@ kind: Deployment
 metadata:
   labels:
     harness.io/name: PUT_YOUR_DELEGATE_NAME
-  name: PUT_YOUR_DELEGATE_NAME
+  name: delegate
   namespace: harness-delegate-ng
 spec:
   replicas: 1


### PR DESCRIPTION
Jira:
https://harness.atlassian.net/browse/DEL-5592

Change delegate deployment name to be 'delegate'. If not, upgrader will fail not being able to find it.

[DEL-5592]: https://harness.atlassian.net/browse/DEL-5592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ