### PR TITLE
fix: [DEL-6030]: keep file same as the one in manager code

### DIFF
--- a/harness-delegate.yaml
+++ b/harness-delegate.yaml
@@ -79,7 +79,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 10
-          failureThreshold: 20
+          failureThreshold: 3
         startupProbe:
           httpGet:
             path: /api/health
@@ -177,6 +177,17 @@ metadata:
 ---
 
 apiVersion: v1
+kind: Secret
+metadata:
+  name: PUT_YOUR_DELEGATE_NAME-upgrader-token
+  namespace: harness-delegate-ng
+type: Opaque
+data:
+  UPGRADER_TOKEN: "PUT_YOUR_DELEGATE_TOKEN"
+
+---
+
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: PUT_YOUR_DELEGATE_NAME-upgrader-config
@@ -216,7 +227,7 @@ spec:
             imagePullPolicy: Always
             envFrom:
             - secretRef:
-                name: PUT_YOUR_DELEGATE_NAME-account-token
+                name: PUT_YOUR_DELEGATE_NAME-upgrader-token
             volumeMounts:
               - name: config-volume
                 mountPath: /etc/config

--- a/harness-delegate.yaml
+++ b/harness-delegate.yaml
@@ -58,7 +58,7 @@ spec:
       terminationGracePeriodSeconds: 600
       restartPolicy: Always
       containers:
-      - image: harness/delegate:23.02.78306
+      - image: PUT_YOUR_DELEGATE_IMAGE
         imagePullPolicy: Always
         name: delegate
         securityContext:


### PR DESCRIPTION
Keep file same as the one from manager code.
I generated two files, one from the raw manifest, one from the harness UI, compared the two files.

This is the PR to fix the key differences between them.
Ignored naming and label differences. 

<img width="494" alt="Screen Shot 2023-02-24 at 11 03 04 PM" src="https://user-images.githubusercontent.com/109999795/221343727-82356d2e-a80b-47fd-8849-e978b52111c1.png">
